### PR TITLE
footer version fix

### DIFF
--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@im-ui/footer",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
Latest package.json version of footer was 0.3.1, npm published version 0.3.2, it caused unpredictable behavior for dependencies (For example older versions of dependent im-components were fetched during npm install).