### PR TITLE
[HT-197] Added new loading spinner logo component

### DIFF
--- a/packages/loadingSpinnerInstamotion/build/tsconfig.cjs.json
+++ b/packages/loadingSpinnerInstamotion/build/tsconfig.cjs.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "module": "commonjs",
+    "outDir": "../dist/cjs",
+    "rootDirs": ["../src", "../stories"]
+  },
+  "exclude": [
+    "../node_modules",
+    "../dist"
+  ],
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.tsx"
+  ]
+}

--- a/packages/loadingSpinnerInstamotion/build/tsconfig.esm.json
+++ b/packages/loadingSpinnerInstamotion/build/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "module": "esnext",
+    "outDir": "../dist/esm",
+    "rootDirs": ["../src", "../stories"]
+  },
+  "exclude": [
+    "../node_modules",
+    "../dist"
+  ],
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.tsx"
+  ]
+}

--- a/packages/loadingSpinnerInstamotion/package.json
+++ b/packages/loadingSpinnerInstamotion/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@im-ui/loading-spinner-instamotion",
+  "version": "0.1.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "author": "InstaMotion Retail GmbH",
+  "scripts": {
+    "build": "npm run clean && npm run compile:esm && npm run compile:cjs",
+    "clean": "rm -rf ./dist",
+    "compile:esm": "tsc -p build/tsconfig.esm.json",
+    "compile:cjs": "tsc -p build/tsconfig.cjs.json",
+    "prepublishOnly": "bolt build"
+  },
+  "repository": "git@github.com:Instamotion/im-components.git",
+  "maintainers": [
+    "Ivan D",
+    "Oleg P",
+    "Anatolii P",
+    "Max K"
+  ],
+  "license": "MIT",
+  "files": ["dist"],
+  "devDependencies": {
+    "@types/jest": "^24.0.21",
+    "@types/react": "^16.9.11",
+    "@types/styled-components": "^4.1.20",
+    "jest": "^24.9.0",
+    "typescript": "^3.6.4"
+  },
+  "peerDependencies": {
+    "react": "^16.11.0",
+    "styled-components": "^4.4.1"
+  },
+  "dependencies": {
+    "@im-ui/theme": "^1.0.0"
+  }
+}

--- a/packages/loadingSpinnerInstamotion/src/index.ts
+++ b/packages/loadingSpinnerInstamotion/src/index.ts
@@ -1,0 +1,1 @@
+export { default, LoadingSpinnerInstamotionProps } from './loadingSpinnerInstamotion';

--- a/packages/loadingSpinnerInstamotion/src/loadingSpinnerInstamotion.tsx
+++ b/packages/loadingSpinnerInstamotion/src/loadingSpinnerInstamotion.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { FlattenSimpleInterpolation } from 'styled-components';
+
+export type LoadingSpinnerInstamotionProps = {
+  centered?: boolean;
+};
+
+const positionCenter = (): FlattenSimpleInterpolation => css`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate3d(-50%, -50%, 0);
+`;
+
+const Spinner = styled.img<LoadingSpinnerInstamotionProps>`
+  display: inline-block;
+  width: 64px;
+  height: 64px;
+
+  ${({ centered }) =>
+    centered
+      ? positionCenter()
+      : css`
+          position: relative;
+        `}
+`;
+
+const LoadingSpinnerInstamotion: React.FC<LoadingSpinnerInstamotionProps> = props => (
+  <Spinner {...props} src="https://cdn.instamotion.com/images/loading-spinner.gif" />
+);
+
+export default LoadingSpinnerInstamotion;

--- a/packages/loadingSpinnerInstamotion/stories/loadingSpinnerInstamotion.stories.tsx
+++ b/packages/loadingSpinnerInstamotion/stories/loadingSpinnerInstamotion.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import LoadingSpinnerInstamotion from '../src';
+
+storiesOf('Loading Spinner Instamotion', module)
+  .add('in the wild', () => {
+    return <LoadingSpinnerInstamotion />;
+  })
+  .add('centered', () => {
+    return <LoadingSpinnerInstamotion centered />;
+  });

--- a/packages/loadingSpinnerInstamotion/tests/loadingSpinnerInstamotion.test.tsx
+++ b/packages/loadingSpinnerInstamotion/tests/loadingSpinnerInstamotion.test.tsx
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+import React from 'react';
+import { mount } from 'enzyme';
+import LoadingSpinnerInstamotion from '../src';
+
+describe('LoadingSpinnerInstamotion', () => {
+  it('renders', () => {
+    const wrapper = mount(<LoadingSpinnerInstamotion />);
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/packages/loadingSpinnerInstamotion/tsconfig.json
+++ b/packages/loadingSpinnerInstamotion/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
According to the financing confirmation page design, we would like to display this logo while loading financing outcome from Bank11 API.